### PR TITLE
Update Individual class: add orcid slot and change name slot

### DIFF
--- a/src/brc_schema/schema/brc_schema.yaml
+++ b/src/brc_schema/schema/brc_schema.yaml
@@ -212,24 +212,24 @@ classes:
     attributes:
       creatorName:
         range: string
-        description: "Name of the creator."
+        description: "Name of the individual."
         slot_uri: schema:name
       email:
         range: string
-        description: "Email address of the creator."
+        description: "Email address of the individual."
         slot_uri: schema:email
       primaryContact:
         range: boolean
-        description: "Indicates if the creator is the primary contact."
+        description: "Indicates if the individual is a primary contact."
       affiliation:
         any_of:
           - range: Organization
           - range: string
-        description: "Affiliation of the creator."
+        description: "Affiliation of the individual."
       orcid:
         range: uriorcurie
         description: >-
-          ORCID for the creator. This should include the
+          ORCID for the individual. This should include the
           full URI with prefix, e.g.,
           https://orcid.org/0000-0002-1825-0097.
 

--- a/src/brc_schema/schema/brc_schema.yaml
+++ b/src/brc_schema/schema/brc_schema.yaml
@@ -210,7 +210,7 @@ classes:
       - schema:Person
       - osti:author
     attributes:
-      creatorName:
+      name:
         range: string
         description: "Name of the individual."
         slot_uri: schema:name

--- a/src/brc_schema/schema/brc_schema.yaml
+++ b/src/brc_schema/schema/brc_schema.yaml
@@ -226,6 +226,13 @@ classes:
           - range: Organization
           - range: string
         description: "Affiliation of the creator."
+      orcid:
+        range: uriorcurie
+        description: >-
+          ORCID for the creator. This should include the
+          full URI with prefix, e.g.,
+          https://orcid.org/0000-0002-1825-0097.
+
 
   Funding:
     description: >-

--- a/src/data/examples/valid/DatasetCollection-JBEI_plasmid_test.json
+++ b/src/data/examples/valid/DatasetCollection-JBEI_plasmid_test.json
@@ -4,7 +4,7 @@
       "date": "2011-07-08",
       "creator": [
         {
-          "creatorName": "Robert Dahl",
+          "name": "Robert Dahl",
           "email": "",
           "primaryContact": true,
           "affiliation": "Joint BioEnergy Institute, Lawrence Berkeley National Laboratory Berkeley CA 94720"


### PR DESCRIPTION
This changes the `creatorName` slot on `Individual` to `name` as an Individual may have a role other than creator.
This is a breaking change.