### PR TITLE
Fix the announce workflow failure

### DIFF
--- a/.github/workflows/announce-update.yaml
+++ b/.github/workflows/announce-update.yaml
@@ -21,5 +21,5 @@ jobs:
         run: |
           curl -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
                -H "Content-Type: application/json" \
-               -d '{"title": "Update to new version of BRC Schema - ${{ github.event.release.name }}", "body": "A new schema update ( ${{ github.event.release.name }} ) has been made. Please review the changes and update this repo accordingly. Release notes: ${{ github.event.release.body }} "}' \
+              -d '{"title": "Update to new version of BRC Schema - ${{ github.event.release.name }}", "body": "A new schema update ( ${{ github.event.release.name }} ) has been made. Please review the changes and update this repo accordingly. [Release notes](https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }})"}' \
                https://api.github.com/repos/bioenergy-research-centers/bioenergy.org/issues


### PR DESCRIPTION
Now the new release announcement should just link to the new release notes instead of sending their full text.