### PR TITLE
Fix relatedItemType mapping returning dict instead of string

### DIFF
--- a/src/brc_schema/transform/osti_to_brc.yaml
+++ b/src/brc_schema/transform/osti_to_brc.yaml
@@ -353,12 +353,17 @@ class_derivations:
       relatedItemType:
         expr: |
           # Map OSTI identifier types to BRC CitedItemType
-          # This is a basic mapping; may need refinement
-          type_map = {
-            'DOI': 'JournalArticle',
-            'URL': 'Webpage',
-            'URI': 'Webpage',
-            'arXiv': 'Preprint',
-            'ISBN': 'Book'
-          }
-          target = type_map.get(src.type, None)
+          # Note: must use if/elif rather than a dict.get() lookup because
+          # the restricted expression evaluator (simpleeval) returns the raw
+          # dict literal for multi-line dict-assignment expressions instead of
+          # failing, causing the entire type_map to be written as the value.
+          if src.type == 'DOI':
+            target = 'JournalArticle'
+          elif src.type in ('URL', 'URI'):
+            target = 'Webpage'
+          elif src.type == 'arXiv':
+            target = 'Preprint'
+          elif src.type == 'ISBN':
+            target = 'Book'
+          else:
+            target = None


### PR DESCRIPTION
Note, this is from Claude... Review carefully...

The type_map dict-literal + .get() pattern is silently mishandled by simpleeval (the restricted expression evaluator used as the first pass in linkml-map). simpleeval evaluates only the first expression in a multi-statement block, returns the raw dict literal, and does not raise an exception -- so the correct asteval fallback is never triggered.

Result: every relatedItemType slot was populated with the entire type_map dict object instead of the looked-up string value, causing validation errors on every related identifier in the output.

Fix: rewrite as an if/elif chain, which raises FeatureNotAvailable in simpleeval and correctly hands off to asteval for evaluation.

Validated against the full CBI OSTI record set: 0 linkml-validate errors after fix (all errors previously were relatedItemType).