### PR TITLE
Fix OSTI to BRC date and BRC mapping

### DIFF
--- a/src/brc_schema/transform.py
+++ b/src/brc_schema/transform.py
@@ -17,6 +17,24 @@ OSTI_SCHEMA_PATH = SCHEMA_DIR / "osti_schema.yaml"
 BRC_TO_OSTI_TR_PATH = TRANSFORM_DIR / "brc_to_osti.yaml"
 OSTI_TO_BRC_TR_PATH = TRANSFORM_DIR / "osti_to_brc.yaml"
 
+BRC_CONTRACTS = {
+    "SC0018420": "CABBI",
+    "SC0018409": "GLBRC",
+    "AC36-08GO28308": "CBI",
+    "AC02-05CH11231": "JBEI",
+}
+
+BRC_ALIASES = {
+    "CABBI": "CABBI",
+    "CENTER FOR ADVANCED BIOENERGY AND BIOPRODUCTS INNOVATION": "CABBI",
+    "CBI": "CBI",
+    "CENTER FOR BIOENERGY INNOVATION": "CBI",
+    "GLBRC": "GLBRC",
+    "GREAT LAKES BIOENERGY RESEARCH CENTER": "GLBRC",
+    "JBEI": "JBEI",
+    "JOINT BIOENERGY INSTITUTE": "JBEI",
+}
+
 
 def _attr(obj, name, default=None):
     if obj is None:
@@ -61,12 +79,7 @@ def _split_name(name):
 
 
 def _brc_contract(brc):
-    return {
-        "CABBI": "SC0018420",
-        "GLBRC": "SC0018409",
-        "CBI": "AC36-08GO28308",
-        "JBEI": "AC02-05CH11231",
-    }.get(brc)
+    return {brc_value: contract for contract, brc_value in BRC_CONTRACTS.items()}.get(brc)
 
 
 def _brc_research_org(brc):
@@ -123,6 +136,71 @@ def _dedupe(items):
     return deduped
 
 
+def _normalize_date(value):
+    if value is None:
+        return None
+    value = str(value).strip()
+    if not value:
+        return None
+    match = re.match(r"^(\d{4}-\d{2}-\d{2})", value)
+    if match:
+        return match.group(1)
+    return value
+
+
+def _normalize_doi(value):
+    if value is None:
+        return None
+    value = str(value).strip()
+    if not value:
+        return None
+    value = re.sub(r"^doi:\s*", "", value, flags=re.IGNORECASE)
+    value = re.sub(r"^https?://(?:dx\.)?doi\.org/", "", value, flags=re.IGNORECASE)
+    return value or None
+
+
+def _normalize_contract(value):
+    if value is None:
+        return None
+    value = str(value).strip().upper()
+    if not value:
+        return None
+    value = re.sub(r"\s+", "", value)
+    if value.startswith("DE-"):
+        value = value[3:]
+    elif value.startswith("DE") and len(value) > 2 and value[2:].startswith(("AC", "SC")):
+        value = value[2:]
+    return value
+
+
+def _contract_values(value):
+    values = []
+    for item in _as_list(value):
+        if item is None:
+            continue
+        for part in re.split(r"[,;|]", str(item)):
+            normalized = _normalize_contract(part)
+            if normalized:
+                values.append(normalized)
+    return values
+
+
+def _brc_from_text(value):
+    if value is None:
+        return None
+    value = str(value).strip().upper()
+    if not value:
+        return None
+    for alias, brc in BRC_ALIASES.items():
+        if alias == value:
+            return brc
+        if len(alias) <= 5 and re.search(rf"\b{re.escape(alias)}\b", value):
+            return brc
+        if len(alias) > 5 and alias in value:
+            return brc
+    return None
+
+
 def build_brc_keywords(keywords, subjects):
     source_keywords = keywords or subjects
     if not source_keywords:
@@ -137,6 +215,58 @@ def build_brc_keywords(keywords, subjects):
         elif item:
             result.append(str(item))
     return result or None
+
+
+def build_brc_date(publication_date, entry_date):
+    return _normalize_date(publication_date) or _normalize_date(entry_date)
+
+
+def build_brc_value(
+    site_ownership_code,
+    doe_contract_number,
+    contract_number,
+    identifiers,
+    organizations,
+    sponsor_orgs,
+    research_orgs,
+):
+    brc = _brc_from_text(site_ownership_code)
+    if brc:
+        return brc
+
+    contract_candidates = []
+    contract_candidates.extend(_contract_values(doe_contract_number))
+    contract_candidates.extend(_contract_values(contract_number))
+
+    for identifier in _as_list(identifiers):
+        id_type = _attr(identifier, "type")
+        id_value = _attr(identifier, "value")
+        if id_type in {"CN_DOE", "CN"}:
+            contract_candidates.extend(_contract_values(id_value))
+
+    for org in _as_list(organizations):
+        for identifier in _as_list(_attr(org, "identifiers")):
+            id_type = _attr(identifier, "type")
+            id_value = _attr(identifier, "value")
+            if id_type in {"CN_DOE", "CN"}:
+                contract_candidates.extend(_contract_values(id_value))
+
+    for contract in contract_candidates:
+        brc = BRC_CONTRACTS.get(contract)
+        if brc:
+            return brc
+
+    for values in [research_orgs, sponsor_orgs, organizations]:
+        for item in _as_list(values):
+            brc = _brc_from_text(_attr(item, "name", item))
+            if brc:
+                return brc
+    return None
+
+
+def build_brc_bibliographic_citation(doi):
+    normalized_doi = _normalize_doi(doi)
+    return f"https://doi.org/{normalized_doi}" if normalized_doi else None
 
 
 def build_brc_creators(persons, authors, organizations):
@@ -482,6 +612,9 @@ def _register_transform_functions():
     eval_utils.FUNCTIONS.update(
         {
             "brc_contract": _brc_contract,
+            "build_brc_date": build_brc_date,
+            "build_brc_value": build_brc_value,
+            "build_brc_bibliographic_citation": build_brc_bibliographic_citation,
             "build_brc_keywords": build_brc_keywords,
             "build_brc_creators": build_brc_creators,
             "build_brc_contributors": build_brc_contributors,

--- a/src/brc_schema/transform/osti_to_brc.yaml
+++ b/src/brc_schema/transform/osti_to_brc.yaml
@@ -19,37 +19,7 @@ class_derivations:
     populated_from: Record
     slot_derivations:
       brc:
-        expr: |
-          # Check site_ownership_code first (direct passthrough)
-          if src.site_ownership_code:
-            target = src.site_ownership_code
-          else:
-            # Map DOE contract numbers to BRC values
-            # Check multiple possible locations for the contract number
-            contract_map = {
-              'SC0018420': 'CABBI',
-              'SC0018409': 'GLBRC',
-              'AC36-08GO28308': 'CBI',
-              'AC02-05CH11231': 'JBEI'
-            }
-            
-            contract_num = None
-            
-            # Check doe_contract_number field (deprecated but may be present)
-            if src.doe_contract_number:
-              contract_num = src.doe_contract_number
-            # Check contract_number field (deprecated but may be present)
-            elif src.contract_number:
-              contract_num = src.contract_number
-            # Check identifiers list for CN_DOE type
-            elif src.identifiers:
-              for identifier in src.identifiers:
-                if identifier.type == 'CN_DOE':
-                  contract_num = identifier.value
-                  break
-            
-            # Map to BRC value if found in our mapping
-            target = contract_map.get(contract_num, None) if contract_num else None
+        expr: "build_brc_value(site_ownership_code, doe_contract_number, contract_number, identifiers, organizations, sponsor_orgs, research_orgs)"
       title:
         populated_from: title
       description:
@@ -57,7 +27,7 @@ class_derivations:
       abstract:
         populated_from: description
       date:
-        expr: "publication_date if publication_date else entry_date"
+        expr: "build_brc_date(publication_date, entry_date)"
       issue:
         expr: "issue if issue else journal_issue"
       identifier:
@@ -67,11 +37,7 @@ class_derivations:
           else:
             target = None
       bibliographicCitation:
-        expr: |
-          if src.doi:
-            target = 'https://doi.org/' + src.doi
-          else:
-            target = None
+        expr: "build_brc_bibliographic_citation(doi)"
       keywords:
         expr: "build_brc_keywords(keywords, subjects)"
       journal_license_url:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -393,6 +393,110 @@ class TestTransformations:
             elif i == 4:  # Invalid identifiers
                 assert brc_value is None
 
+    def test_osti_to_brc_normalizes_cbi_dates_contracts_and_dois(self, tmp_path):
+        """CBI-style OSTI records should produce schema-valid dates, BRC values, and DOI URLs."""
+        test_data = {
+            "records": [
+                {
+                    "osti_id": "2352359",
+                    "title": "CBI Dataset with URL DOI",
+                    "publication_date": "2024-05-16T20:00:00Z",
+                    "doi": "https://doi.org/10.1186/s12934-024-02414-0",
+                    "identifiers": [
+                        {"type": "CN_DOE", "value": "DE-AC36-08GO28308"}
+                    ],
+                    "authors": ["Jane Doe"],
+                },
+                {
+                    "osti_id": "2202296",
+                    "title": "CBI Dataset with organization contract",
+                    "entry_date": "2023-10-13T20:00:00Z",
+                    "doi": "doi:10.1186/s13068-023-02393-1",
+                    "organizations": [
+                        {
+                            "type": "SPONSOR",
+                            "name": "USDOE Office of Science",
+                            "identifiers": [
+                                {"type": "CN_DOE", "value": "DEAC36-08GO28308"}
+                            ],
+                        }
+                    ],
+                    "authors": ["John Smith"],
+                },
+            ]
+        }
+
+        input_file = tmp_path / "cbi_osti_input.json"
+        with open(input_file, 'w') as f:
+            json.dump(test_data, f)
+
+        output_file = tmp_path / "cbi_brc_output.json"
+
+        test_args = [
+            'brcschema', 'transform',
+            '-T', 'osti_to_brc',
+            '-o', str(output_file),
+            str(input_file)
+        ]
+
+        with patch.object(sys, 'argv', test_args):
+            try:
+                main()
+            except SystemExit:
+                pass
+
+        with open(output_file, 'r') as f:
+            result = json.load(f)
+
+        first, second = result['datasets']
+        assert first['brc'] == 'CBI'
+        assert first['date'] == '2024-05-16'
+        assert first['bibliographicCitation'] == 'https://doi.org/10.1186/s12934-024-02414-0'
+        assert second['brc'] == 'CBI'
+        assert second['date'] == '2023-10-13'
+        assert second['bibliographicCitation'] == 'https://doi.org/10.1186/s13068-023-02393-1'
+
+    def test_osti_to_brc_infers_brc_from_organization_aliases(self, tmp_path):
+        """Current OSTI organization text should be usable when contract fields are absent."""
+        test_data = {
+            "records": [{
+                "osti_id": "12345",
+                "title": "Dataset with CBI organization text",
+                "publication_date": "2024-01-01",
+                "organizations": [
+                    {
+                        "type": "AUTHOR",
+                        "name": "Oak Ridge National Laboratory (ORNL), Oak Ridge, TN (United States). Center for Bioenergy Innovation (CBI)",
+                    }
+                ],
+                "authors": ["Jane Doe"],
+            }]
+        }
+
+        input_file = tmp_path / "cbi_org_input.json"
+        with open(input_file, 'w') as f:
+            json.dump(test_data, f)
+
+        output_file = tmp_path / "cbi_org_output.json"
+
+        test_args = [
+            'brcschema', 'transform',
+            '-T', 'osti_to_brc',
+            '-o', str(output_file),
+            str(input_file)
+        ]
+
+        with patch.object(sys, 'argv', test_args):
+            try:
+                main()
+            except SystemExit:
+                pass
+
+        with open(output_file, 'r') as f:
+            result = json.load(f)
+
+        assert result['datasets'][0]['brc'] == 'CBI'
+
     def test_fallback_authors_field(self, tmp_path):
         """Test fallback to authors field when persons is not available."""
         data_with_authors = {


### PR DESCRIPTION
## Summary
- normalize OSTI publication/entry datetimes to BRC date strings
- make OSTI-to-BRC affiliation mapping more robust across site codes, DOE contract identifiers, organization identifiers, and organization names
- normalize DOI values before building bibliographic citation URLs

Fixes #141

## Testing
- uv run pytest -q tests/test_transforms.py tests/test_transform_module.py
- make test
- git diff --check