### PR TITLE
Add OSTI site-code retrieval command

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ uv run brcschema -vv retrieve-osti --osti-ids 2584700 -o records.json
 
 #### `retrieve-osti-site` - Retrieve OSTI records by site code
 
-Retrieve records for a DOE site ownership code from the legacy/public OSTI API, the E-Link 2.0 API, or both. The output keeps a top-level `records` list for transforms and adds `retrieval_sources` plus `record_origins` metadata so each record's source API and origin schema are explicit.
+Retrieve records for a DOE site ownership code from legacy E-Link 1, E-Link 2.0, the public OSTI.GOV records API, or an authentication-dependent combination of those sources. The output keeps a top-level `records` list for transforms and adds `retrieval_sources` plus `record_origins` metadata so each record's source API and origin schema are explicit.
 
 ```bash
 uv run brcschema retrieve-osti-site --site-code GLBRC -o glbrc_records.json
@@ -167,10 +167,14 @@ uv run brcschema retrieve-osti-site --site-code GLBRC -o glbrc_records.json
 
 Useful options:
 
-- `--source legacy` or `--source elink2`: restrict retrieval to one source API. Repeat the option to use both; omitting it defaults to both.
+- `--source legacy`, `--source elink2`, or `--source public`: restrict retrieval to one source API. Repeat the option to combine sources.
 - `--entry-date-start YYYY-MM-DD` and `--entry-date-end YYYY-MM-DD`: retrieve records in a date window.
 - `--product-type TEXT`: optionally restrict by OSTI product type.
 - `--limit N`: keep up to N records from each source.
+- `--api-key` or `OSTI_API_KEY`: required for E-Link 2.0 retrieval.
+- `--legacy-username`/`--legacy-password` or `OSTI_LEGACY_USERNAME`/`OSTI_LEGACY_PASSWORD`: required for legacy E-Link 1 retrieval.
+
+If no authentication is provided, the command warns and uses only the public OSTI.GOV records API, so results may exclude non-public legacy E-Link records and E-Link 2.0 is skipped. If only an E-Link 2.0 API key is available, the default sources are `public` and `elink2`. If both legacy and E-Link 2.0 credentials are available, the default sources are `legacy` and `elink2`.
 
 ### Complete Workflow Example
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ uv run brcschema retrieve-osti --osti-ids 2584700 --dois 10.11578/2584700 --api-
 uv run brcschema -vv retrieve-osti --osti-ids 2584700 -o records.json
 ```
 
+#### `retrieve-osti-site` - Retrieve OSTI records by site code
+
+Retrieve records for a DOE site ownership code from the legacy/public OSTI API, the E-Link 2.0 API, or both. The output keeps a top-level `records` list for transforms and adds `retrieval_sources` plus `record_origins` metadata so each record's source API and origin schema are explicit.
+
+```bash
+uv run brcschema retrieve-osti-site --site-code GLBRC -o glbrc_records.json
+```
+
+Useful options:
+
+- `--source legacy` or `--source elink2`: restrict retrieval to one source API. Repeat the option to use both; omitting it defaults to both.
+- `--entry-date-start YYYY-MM-DD` and `--entry-date-end YYYY-MM-DD`: retrieve records in a date window.
+- `--product-type TEXT`: optionally restrict by OSTI product type.
+- `--limit N`: keep up to N records from each source.
+
 ### Complete Workflow Example
 
 Retrieve OSTI records and transform them to BRC format:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,6 +134,55 @@ uv run brcschema retrieve-osti --osti-ids 2584700 -o records.json --api-key YOUR
 
 ---
 
+### `retrieve-osti-site`
+
+Retrieve OSTI records for a DOE site ownership code from the legacy/public OSTI API, E-Link 2.0, or both.
+
+**Usage:**
+
+```bash
+uv run brcschema retrieve-osti-site --site-code <site_code> -o <output_file>
+```
+
+**Options:**
+
+- `--site-code` **(required)**: DOE site ownership code, such as `GLBRC`, `CBI`, `CABBI`, or `JBEI`
+- `--source`: Source API to query, either `legacy` or `elink2`; repeat to query both. If omitted, both are queried.
+- `--product-type`: Optional OSTI product type filter
+- `--entry-date-start`: Optional lower entry-date boundary. `YYYY-MM-DD` is converted to OSTI's `MM/DD/YYYY` query format.
+- `--entry-date-end`: Optional upper entry-date boundary. `YYYY-MM-DD` is converted to OSTI's `MM/DD/YYYY` query format.
+- `--rows`: Rows requested from each source API. Defaults to `500`.
+- `-l, --limit`: Maximum records to keep from each source API
+- `-o, --output` **(required)**: Output JSON file path
+- `--api-key`: E-Link 2.0 API key, alternatively set `OSTI_API_KEY`
+- `--api-url`: Optional E-Link 2.0 API URL
+- `--legacy-api-url`: Optional legacy/public OSTI record API URL
+- `--no-pretty`: Disable pretty-printing of JSON output
+
+**Examples:**
+
+```bash
+# Query both source APIs for GLBRC records
+uv run brcschema retrieve-osti-site --site-code GLBRC -o glbrc_records.json
+
+# Query only E-Link 2.0 for recently entered records
+uv run brcschema retrieve-osti-site --site-code GLBRC --source elink2 --entry-date-start 2026-01-01 -o glbrc_elink2.json
+
+# Query only legacy/public OSTI records
+uv run brcschema retrieve-osti-site --site-code CBI --source legacy --limit 100 -o cbi_legacy.json
+```
+
+**Output Metadata:**
+
+The output includes a transform-compatible top-level `records` list and additional metadata:
+
+- `retrieval_sources`: one entry per source API, including `api`, `origin_schema`, `normalized_schema`, query parameters, and counts
+- `record_origins`: one entry per record index, identifying the record's source API and origin schema
+
+This lets downstream scripts distinguish legacy/public OSTI API records (`osti_public_api_v1_json`) from E-Link 2.0 records (`osti_elink2_json`) while still feeding the same `records` list to `transform -T osti_to_brc`.
+
+---
+
 ### `transmit-osti`
 
 Transmit metadata records to OSTI E-Link 2.0 API, creating new records or updating existing ones.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,7 +136,7 @@ uv run brcschema retrieve-osti --osti-ids 2584700 -o records.json --api-key YOUR
 
 ### `retrieve-osti-site`
 
-Retrieve OSTI records for a DOE site ownership code from the legacy/public OSTI API, E-Link 2.0, or both.
+Retrieve OSTI records for a DOE site ownership code from legacy E-Link 1, E-Link 2.0, the public OSTI.GOV records API, or an authentication-dependent combination of those sources.
 
 **Usage:**
 
@@ -147,29 +147,37 @@ uv run brcschema retrieve-osti-site --site-code <site_code> -o <output_file>
 **Options:**
 
 - `--site-code` **(required)**: DOE site ownership code, such as `GLBRC`, `CBI`, `CABBI`, or `JBEI`
-- `--source`: Source API to query, either `legacy` or `elink2`; repeat to query both. If omitted, both are queried.
+- `--source`: Source API to query: `legacy`, `elink2`, or `public`; repeat to query more than one source.
 - `--product-type`: Optional OSTI product type filter
 - `--entry-date-start`: Optional lower entry-date boundary. `YYYY-MM-DD` is converted to OSTI's `MM/DD/YYYY` query format.
 - `--entry-date-end`: Optional upper entry-date boundary. `YYYY-MM-DD` is converted to OSTI's `MM/DD/YYYY` query format.
 - `--rows`: Rows requested from each source API. Defaults to `500`.
 - `-l, --limit`: Maximum records to keep from each source API
 - `-o, --output` **(required)**: Output JSON file path
-- `--api-key`: E-Link 2.0 API key, alternatively set `OSTI_API_KEY`
+- `--api-key`: E-Link 2.0 API key, alternatively set `OSTI_API_KEY`; required when `elink2` is selected
 - `--api-url`: Optional E-Link 2.0 API URL
-- `--legacy-api-url`: Optional legacy/public OSTI record API URL
+- `--legacy-api-url`: Optional legacy E-Link 1 XML API URL
+- `--legacy-username`: Legacy E-Link 1 username, alternatively set `OSTI_LEGACY_USERNAME`; required when `legacy` is selected
+- `--legacy-password`: Legacy E-Link 1 password, alternatively set `OSTI_LEGACY_PASSWORD`; required when `legacy` is selected
+- `--public-api-url`: Optional public OSTI.GOV record API URL
 - `--no-pretty`: Disable pretty-printing of JSON output
+
+Default source selection depends on available credentials. With no authentication, the command warns and uses only `public`, which can return only public/released OSTI.GOV records. With only an E-Link 2.0 API key, the command uses `public` and `elink2`. With both legacy E-Link 1 and E-Link 2.0 credentials, it uses `legacy` and `elink2`.
 
 **Examples:**
 
 ```bash
-# Query both source APIs for GLBRC records
+# Query the default sources for the credentials available in the environment
 uv run brcschema retrieve-osti-site --site-code GLBRC -o glbrc_records.json
 
 # Query only E-Link 2.0 for recently entered records
 uv run brcschema retrieve-osti-site --site-code GLBRC --source elink2 --entry-date-start 2026-01-01 -o glbrc_elink2.json
 
-# Query only legacy/public OSTI records
-uv run brcschema retrieve-osti-site --site-code CBI --source legacy --limit 100 -o cbi_legacy.json
+# Query only legacy E-Link 1 records
+uv run brcschema retrieve-osti-site --site-code CBI --source legacy --legacy-username "$OSTI_LEGACY_USERNAME" --legacy-password "$OSTI_LEGACY_PASSWORD" --limit 100 -o cbi_legacy.json
+
+# Query only public OSTI.GOV records
+uv run brcschema retrieve-osti-site --site-code CBI --source public --limit 100 -o cbi_public.json
 ```
 
 **Output Metadata:**
@@ -179,7 +187,7 @@ The output includes a transform-compatible top-level `records` list and addition
 - `retrieval_sources`: one entry per source API, including `api`, `origin_schema`, `normalized_schema`, query parameters, and counts
 - `record_origins`: one entry per record index, identifying the record's source API and origin schema
 
-This lets downstream scripts distinguish legacy/public OSTI API records (`osti_public_api_v1_json`) from E-Link 2.0 records (`osti_elink2_json`) while still feeding the same `records` list to `transform -T osti_to_brc`.
+This lets downstream scripts distinguish legacy E-Link 1 records (`osti_elink1_xml`), public OSTI.GOV records (`osti_public_api_v1_json`), and E-Link 2.0 records (`osti_elink2_json`) while still feeding the same `records` list to `transform -T osti_to_brc`.
 
 ---
 

--- a/docs/osti_elink_integration.md
+++ b/docs/osti_elink_integration.md
@@ -64,6 +64,21 @@ Mix OSTI IDs and DOIs:
 uv run brcschema retrieve-osti --osti-ids 2584700 --dois 10.11578/2584700 -o records.json
 ```
 
+Retrieve by BRC/site code from both source APIs:
+
+```bash
+uv run brcschema retrieve-osti-site --site-code GLBRC -o glbrc_records.json
+```
+
+Restrict retrieval to one source API when needed:
+
+```bash
+uv run brcschema retrieve-osti-site --site-code GLBRC --source legacy -o glbrc_legacy.json
+uv run brcschema retrieve-osti-site --site-code GLBRC --source elink2 -o glbrc_elink2.json
+```
+
+The site-code output includes `records` plus `retrieval_sources` and `record_origins`. `record_origins` identifies the source API and origin schema for each record index, such as `osti_public_api_v1_json` for legacy/public OSTI API records and `osti_elink2_json` for E-Link 2.0 records.
+
 ## Python API Examples
 
 ### Convenience Function

--- a/docs/osti_elink_integration.md
+++ b/docs/osti_elink_integration.md
@@ -64,20 +64,23 @@ Mix OSTI IDs and DOIs:
 uv run brcschema retrieve-osti --osti-ids 2584700 --dois 10.11578/2584700 -o records.json
 ```
 
-Retrieve by BRC/site code from both source APIs:
+Retrieve by BRC/site code from the default sources for the credentials available in the environment:
 
 ```bash
 uv run brcschema retrieve-osti-site --site-code GLBRC -o glbrc_records.json
 ```
 
+With no authentication, this command warns and uses only the public OSTI.GOV records API, which can return only public/released records. E-Link 2.0 retrieval requires `OSTI_API_KEY`, and legacy E-Link 1 retrieval requires `OSTI_LEGACY_USERNAME` plus `OSTI_LEGACY_PASSWORD`.
+
 Restrict retrieval to one source API when needed:
 
 ```bash
-uv run brcschema retrieve-osti-site --site-code GLBRC --source legacy -o glbrc_legacy.json
+uv run brcschema retrieve-osti-site --site-code GLBRC --source legacy --legacy-username "$OSTI_LEGACY_USERNAME" --legacy-password "$OSTI_LEGACY_PASSWORD" -o glbrc_legacy.json
 uv run brcschema retrieve-osti-site --site-code GLBRC --source elink2 -o glbrc_elink2.json
+uv run brcschema retrieve-osti-site --site-code GLBRC --source public -o glbrc_public.json
 ```
 
-The site-code output includes `records` plus `retrieval_sources` and `record_origins`. `record_origins` identifies the source API and origin schema for each record index, such as `osti_public_api_v1_json` for legacy/public OSTI API records and `osti_elink2_json` for E-Link 2.0 records.
+The site-code output includes `records` plus `retrieval_sources` and `record_origins`. `record_origins` identifies the source API and origin schema for each record index, such as `osti_elink1_xml` for legacy E-Link 1 records, `osti_public_api_v1_json` for public OSTI.GOV records, and `osti_elink2_json` for E-Link 2.0 records.
 
 ## Python API Examples
 

--- a/src/brc_schema/cli.py
+++ b/src/brc_schema/cli.py
@@ -210,6 +210,124 @@ def retrieve_osti(
 
 @main.command()
 @click.option(
+    "--site-code",
+    required=True,
+    help="DOE site ownership code to query, such as GLBRC, CBI, CABBI, or JBEI"
+)
+@click.option(
+    "--source",
+    "sources",
+    multiple=True,
+    type=click.Choice(["legacy", "elink2"]),
+    help="OSTI source API to query. Repeat to use both. Defaults to both legacy and elink2."
+)
+@click.option(
+    "--product-type",
+    help="Optional OSTI product type filter"
+)
+@click.option(
+    "--entry-date-start",
+    help="Optional lower entry-date boundary. YYYY-MM-DD is converted to OSTI's MM/DD/YYYY query format."
+)
+@click.option(
+    "--entry-date-end",
+    help="Optional upper entry-date boundary. YYYY-MM-DD is converted to OSTI's MM/DD/YYYY query format."
+)
+@click.option(
+    "--rows",
+    type=int,
+    default=500,
+    show_default=True,
+    help="Rows requested from each source API"
+)
+@click.option(
+    "-l",
+    "--limit",
+    type=int,
+    help="Maximum records to keep from each source API"
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Output JSON file path"
+)
+@click.option(
+    "--api-key",
+    help="OSTI E-Link 2.0 API key (optional, can also use OSTI_API_KEY environment variable)"
+)
+@click.option(
+    "--api-url",
+    help="OSTI E-Link 2.0 API URL (optional, can also use OSTI_API_URL environment variable)"
+)
+@click.option(
+    "--legacy-api-url",
+    help="Legacy/public OSTI record API URL (defaults to https://www.osti.gov/api/v1/records)"
+)
+@click.option(
+    "--no-pretty",
+    is_flag=True,
+    help="Disable pretty-printing of JSON output"
+)
+def retrieve_osti_site(
+    site_code: str,
+    sources: tuple,
+    product_type: Optional[str],
+    entry_date_start: Optional[str],
+    entry_date_end: Optional[str],
+    rows: int,
+    limit: Optional[int],
+    output: Path,
+    api_key: Optional[str],
+    api_url: Optional[str],
+    legacy_api_url: Optional[str],
+    no_pretty: bool
+) -> None:
+    """
+    Retrieve OSTI records for a site code from legacy and E-Link 2.0 APIs.
+
+    The output contains a transform-compatible top-level "records" list plus
+    retrieval metadata that identifies the origin schema for each record.
+    """
+    if rows <= 0:
+        raise click.UsageError("--rows must be greater than zero")
+    if limit is not None and limit < 0:
+        raise click.UsageError("--limit cannot be negative")
+
+    selected_sources = tuple(dict.fromkeys(sources or ("legacy", "elink2")))
+    retriever_kwargs = {"api_key": api_key, "api_url": api_url}
+    if legacy_api_url:
+        retriever_kwargs["legacy_api_url"] = legacy_api_url
+    retriever = OSTIRecordRetriever(**retriever_kwargs)
+
+    try:
+        output_data = retriever.save_records_by_site_code_to_file(
+            output_path=output,
+            site_code=site_code,
+            sources=selected_sources,
+            product_type=product_type,
+            entry_date_start=entry_date_start,
+            entry_date_end=entry_date_end,
+            rows=rows,
+            limit=limit,
+            pretty=not no_pretty,
+        )
+    except Exception as e:
+        logger.error(f"Error retrieving site-code records: {e}", exc_info=True)
+        raise click.ClickException(str(e)) from e
+
+    source_counts = ", ".join(
+        f"{source['api']}={source['record_count']}"
+        for source in output_data["retrieval_sources"]
+    )
+    click.echo(
+        f"✓ Retrieved {len(output_data['records'])} record(s) for {site_code.upper()} "
+        f"({source_counts}) and saved to {output}")
+
+
+@main.command()
+@click.option(
     "--api-key",
     help="OSTI API key (optional, can also use OSTI_API_KEY environment variable)"
 )

--- a/src/brc_schema/cli.py
+++ b/src/brc_schema/cli.py
@@ -1,6 +1,7 @@
 """CLI for brc_schema"""
 
 import logging
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -218,8 +219,8 @@ def retrieve_osti(
     "--source",
     "sources",
     multiple=True,
-    type=click.Choice(["legacy", "elink2"]),
-    help="OSTI source API to query. Repeat to use both. Defaults to both legacy and elink2."
+    type=click.Choice(["legacy", "elink2", "public"]),
+    help="OSTI source API to query. Repeat to use multiple sources. Defaults depend on available credentials."
 )
 @click.option(
     "--product-type",
@@ -263,7 +264,19 @@ def retrieve_osti(
 )
 @click.option(
     "--legacy-api-url",
-    help="Legacy/public OSTI record API URL (defaults to https://www.osti.gov/api/v1/records)"
+    help="Legacy E-Link 1 XML API URL (defaults to https://www.osti.gov/elink/2416api)"
+)
+@click.option(
+    "--legacy-username",
+    help="Legacy E-Link 1 username (optional, can also use OSTI_LEGACY_USERNAME)"
+)
+@click.option(
+    "--legacy-password",
+    help="Legacy E-Link 1 password (optional, can also use OSTI_LEGACY_PASSWORD)"
+)
+@click.option(
+    "--public-api-url",
+    help="Public OSTI.GOV record API URL (defaults to https://www.osti.gov/api/v1/records)"
 )
 @click.option(
     "--no-pretty",
@@ -282,10 +295,13 @@ def retrieve_osti_site(
     api_key: Optional[str],
     api_url: Optional[str],
     legacy_api_url: Optional[str],
+    legacy_username: Optional[str],
+    legacy_password: Optional[str],
+    public_api_url: Optional[str],
     no_pretty: bool
 ) -> None:
     """
-    Retrieve OSTI records for a site code from legacy and E-Link 2.0 APIs.
+    Retrieve OSTI records for a site code from OSTI source APIs.
 
     The output contains a transform-compatible top-level "records" list plus
     retrieval metadata that identifies the origin schema for each record.
@@ -295,10 +311,63 @@ def retrieve_osti_site(
     if limit is not None and limit < 0:
         raise click.UsageError("--limit cannot be negative")
 
-    selected_sources = tuple(dict.fromkeys(sources or ("legacy", "elink2")))
-    retriever_kwargs = {"api_key": api_key, "api_url": api_url}
+    has_elink2_auth = bool(api_key or os.environ.get("OSTI_API_KEY"))
+    has_legacy_auth = bool(
+        (legacy_username or os.environ.get("OSTI_LEGACY_USERNAME"))
+        and (legacy_password or os.environ.get("OSTI_LEGACY_PASSWORD"))
+    )
+    if sources:
+        selected_sources = tuple(dict.fromkeys(sources))
+        if (
+            not has_legacy_auth
+            and not has_elink2_auth
+            and selected_sources == ("public",)
+        ):
+            click.echo(
+                "No OSTI authentication provided; using public OSTI.GOV records only. "
+                "Results may exclude non-public legacy E-Link records.",
+                err=True,
+            )
+    elif has_legacy_auth and has_elink2_auth:
+        selected_sources = ("legacy", "elink2")
+    elif has_legacy_auth:
+        selected_sources = ("legacy",)
+    elif has_elink2_auth:
+        selected_sources = ("public", "elink2")
+        click.echo(
+            "No legacy E-Link 1 credentials provided; using public OSTI.GOV records "
+            "as the unauthenticated fallback. Results may exclude non-public "
+            "legacy E-Link records.",
+            err=True,
+        )
+    else:
+        selected_sources = ("public",)
+        click.echo(
+            "No OSTI authentication provided; using public OSTI.GOV records only. "
+            "Results may exclude non-public legacy E-Link records, and E-Link 2.0 "
+            "is skipped because it requires authentication.",
+            err=True,
+        )
+
+    if "elink2" in selected_sources and not has_elink2_auth:
+        raise click.UsageError(
+            "E-Link 2.0 retrieval requires --api-key or OSTI_API_KEY.")
+    if "legacy" in selected_sources and not has_legacy_auth:
+        raise click.UsageError(
+            "Legacy E-Link 1 retrieval requires --legacy-username/--legacy-password "
+            "or OSTI_LEGACY_USERNAME/OSTI_LEGACY_PASSWORD.")
+
+    retriever_kwargs = {
+        "api_key": api_key,
+        "api_url": api_url,
+        "initialize_elink2": "elink2" in selected_sources,
+        "legacy_username": legacy_username,
+        "legacy_password": legacy_password,
+    }
     if legacy_api_url:
         retriever_kwargs["legacy_api_url"] = legacy_api_url
+    if public_api_url:
+        retriever_kwargs["public_api_url"] = public_api_url
     retriever = OSTIRecordRetriever(**retriever_kwargs)
 
     try:

--- a/src/brc_schema/util/elink.py
+++ b/src/brc_schema/util/elink.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import os
+import base64
+import xml.etree.ElementTree as ET
 from datetime import date, datetime
 from pathlib import Path
 from typing import List, Union, Optional, Dict, Any
@@ -15,8 +17,10 @@ logger = logging.getLogger(__name__)
 
 OSTI_DOI_PREFIX = "10.11578/"
 OSTI_PUBLIC_API_RECORDS_URL = "https://www.osti.gov/api/v1/records"
+OSTI_LEGACY_ELINK_API_URL = "https://www.osti.gov/elink/2416api"
 OSTI_ELINK2_ORIGIN_SCHEMA = "osti_elink2_json"
-OSTI_LEGACY_ORIGIN_SCHEMA = "osti_public_api_v1_json"
+OSTI_LEGACY_ORIGIN_SCHEMA = "osti_elink1_xml"
+OSTI_PUBLIC_ORIGIN_SCHEMA = "osti_public_api_v1_json"
 OSTI_NORMALIZED_SCHEMA = "osti_schema"
 OSTI_SOURCE_METADATA = {
     "elink2": {
@@ -27,6 +31,11 @@ OSTI_SOURCE_METADATA = {
     "legacy": {
         "api": "legacy",
         "origin_schema": OSTI_LEGACY_ORIGIN_SCHEMA,
+        "normalized_schema": OSTI_NORMALIZED_SCHEMA,
+    },
+    "public": {
+        "api": "public",
+        "origin_schema": OSTI_PUBLIC_ORIGIN_SCHEMA,
         "normalized_schema": OSTI_NORMALIZED_SCHEMA,
     },
 }
@@ -42,24 +51,37 @@ class DateTimeEncoder(json.JSONEncoder):
 
 
 class OSTIRecordRetriever:
-    """Retrieve records from OSTI E-Link 2.0 API."""
+    """Retrieve records from OSTI E-Link and public OSTI.GOV APIs."""
 
     def __init__(
         self,
         api_key: Optional[str] = None,
         api_url: Optional[str] = None,
-        legacy_api_url: str = OSTI_PUBLIC_API_RECORDS_URL,
+        legacy_api_url: str = OSTI_LEGACY_ELINK_API_URL,
+        legacy_username: Optional[str] = None,
+        legacy_password: Optional[str] = None,
+        public_api_url: str = OSTI_PUBLIC_API_RECORDS_URL,
+        initialize_elink2: bool = True,
     ):
         """
         Initialize the OSTI record retriever.
 
         Args:
-            api_key: Optional API key for authentication. If not provided,
-                    will attempt to use OSTI_API_KEY environment variable.
+            api_key: Optional E-Link 2.0 API key. If not provided, this will
+                attempt to use OSTI_API_KEY from the environment.
+            legacy_username: Optional legacy E-Link 1 username. If not
+                provided, this will attempt to use OSTI_LEGACY_USERNAME.
+            legacy_password: Optional legacy E-Link 1 password. If not
+                provided, this will attempt to use OSTI_LEGACY_PASSWORD.
+            initialize_elink2: Initialize the E-Link 2.0 client. Site-code
+                retrieval can disable this when E-Link 2.0 is not selected.
         """
         # Use provided API key, or try to get from environment
-        self.api = _init_api(api_key, api_url)
+        self.api = _init_api(api_key, api_url) if initialize_elink2 else None
         self.legacy_api_url = legacy_api_url
+        self.legacy_username = legacy_username or os.environ.get("OSTI_LEGACY_USERNAME")
+        self.legacy_password = legacy_password or os.environ.get("OSTI_LEGACY_PASSWORD")
+        self.public_api_url = public_api_url
 
     def get_record_by_osti_id(self, osti_id: Union[int, str]) -> Optional[Dict[str, Any]]:
         """
@@ -230,12 +252,10 @@ class OSTIRecordRetriever:
         rows: int = 500,
         limit: Optional[int] = None,
     ) -> tuple[list[dict], dict]:
-        """Query OSTI public API v1 records using legacy OSTI record fields."""
+        """Query legacy E-Link 1 XML records for a submitting site code."""
         params = {
-            "site_ownership_code": site_code,
+            "site_input_code": site_code,
             "rows": rows,
-            "sort": "entry_date",
-            "order": "desc",
         }
         if product_type:
             params["product_type"] = product_type
@@ -252,6 +272,43 @@ class OSTIRecordRetriever:
 
         source_metadata = _source_metadata(
             source="legacy",
+            query_params=params,
+            total_rows=response_metadata.get("total_rows"),
+            record_count=len(records),
+        )
+        return records, source_metadata
+
+    def query_public_records(
+        self,
+        site_code: str,
+        product_type: Optional[str] = None,
+        entry_date_start: Optional[str] = None,
+        entry_date_end: Optional[str] = None,
+        rows: int = 500,
+        limit: Optional[int] = None,
+    ) -> tuple[list[dict], dict]:
+        """Query public OSTI.GOV records using legacy-shaped public record fields."""
+        params = {
+            "site_ownership_code": site_code,
+            "rows": rows,
+            "sort": "entry_date",
+            "order": "desc",
+        }
+        if product_type:
+            params["product_type"] = product_type
+        if entry_date_start:
+            params["entry_date_start"] = _format_osti_api_date(entry_date_start)
+        if entry_date_end:
+            params["entry_date_end"] = _format_osti_api_date(entry_date_end)
+        if limit is not None:
+            params["rows"] = min(rows, limit)
+
+        records, response_metadata = self._query_public_api(params)
+        if limit is not None:
+            records = records[:limit]
+
+        source_metadata = _source_metadata(
+            source="public",
             query_params=params,
             total_rows=response_metadata.get("total_rows"),
             record_count=len(records),
@@ -286,6 +343,15 @@ class OSTIRecordRetriever:
                 )
             elif source == "elink2":
                 source_records, source_metadata = self.query_elink2_records(
+                    site_code=site_code,
+                    product_type=product_type,
+                    entry_date_start=entry_date_start,
+                    entry_date_end=entry_date_end,
+                    rows=rows,
+                    limit=limit,
+                )
+            elif source == "public":
+                source_records, source_metadata = self.query_public_records(
                     site_code=site_code,
                     product_type=product_type,
                     entry_date_start=entry_date_start,
@@ -362,7 +428,32 @@ class OSTIRecordRetriever:
         return output_data
 
     def _query_legacy_api(self, params: dict) -> tuple[list[dict], dict]:
+        if not self.legacy_username or not self.legacy_password:
+            raise ValueError(
+                "Legacy E-Link 1 retrieval requires basic-auth credentials. "
+                "Provide --legacy-username/--legacy-password or set "
+                "OSTI_LEGACY_USERNAME and OSTI_LEGACY_PASSWORD."
+            )
         query_url = f"{self.legacy_api_url}?{urlencode(params)}"
+        credentials = f"{self.legacy_username}:{self.legacy_password}".encode("utf-8")
+        auth_header = base64.b64encode(credentials).decode("ascii")
+        request = Request(
+            query_url,
+            headers={
+                "Accept": "application/xml",
+                "Authorization": f"Basic {auth_header}",
+            },
+        )
+        with urlopen(request) as response:
+            payload = response.read().decode("utf-8")
+            total_rows = response.headers.get("X-Total-Count")
+        records = _parse_legacy_elink_xml(payload)
+        return records, {
+            "total_rows": int(total_rows) if total_rows is not None else len(records),
+        }
+
+    def _query_public_api(self, params: dict) -> tuple[list[dict], dict]:
+        query_url = f"{self.public_api_url}?{urlencode(params)}"
         request = Request(query_url, headers={"Accept": "application/json"})
         with urlopen(request) as response:
             payload = response.read().decode("utf-8")
@@ -470,6 +561,50 @@ def _format_osti_api_date(value):
     except ValueError:
         return value
     return parsed.strftime("%m/%d/%Y")
+
+
+def _parse_legacy_elink_xml(payload: str) -> list[dict]:
+    root = ET.fromstring(payload)
+    if _strip_namespace(root.tag) == "record":
+        record_elements = [root]
+    else:
+        record_elements = [
+            element for element in root.iter()
+            if _strip_namespace(element.tag) == "record"
+        ]
+    return [_xml_element_to_dict(element) for element in record_elements]
+
+
+def _xml_element_to_dict(element):
+    children = list(element)
+    if not children:
+        text = element.text.strip() if element.text else ""
+        return text or None
+
+    result = {}
+    for child in children:
+        key = _legacy_key(_strip_namespace(child.tag))
+        value = _xml_element_to_dict(child)
+        if key in result:
+            if not isinstance(result[key], list):
+                result[key] = [result[key]]
+            result[key].append(value)
+        else:
+            result[key] = value
+    return result
+
+
+def _strip_namespace(tag):
+    return tag.rsplit("}", 1)[-1]
+
+
+def _legacy_key(key):
+    return {
+        "site_input_code": "site_ownership_code",
+        "contract_nos": "doe_contract_number",
+        "originating_research_org": "research_orgs",
+        "sponsor_org": "sponsor_orgs",
+    }.get(key, key)
 
 
 def _source_metadata(source, query_params, total_rows, record_count):

--- a/src/brc_schema/util/elink.py
+++ b/src/brc_schema/util/elink.py
@@ -6,12 +6,30 @@ import os
 from datetime import date, datetime
 from pathlib import Path
 from typing import List, Union, Optional, Dict, Any
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 from elinkapi import Elink, Record, exceptions
 
 logger = logging.getLogger(__name__)
 
 OSTI_DOI_PREFIX = "10.11578/"
+OSTI_PUBLIC_API_RECORDS_URL = "https://www.osti.gov/api/v1/records"
+OSTI_ELINK2_ORIGIN_SCHEMA = "osti_elink2_json"
+OSTI_LEGACY_ORIGIN_SCHEMA = "osti_public_api_v1_json"
+OSTI_NORMALIZED_SCHEMA = "osti_schema"
+OSTI_SOURCE_METADATA = {
+    "elink2": {
+        "api": "elink2",
+        "origin_schema": OSTI_ELINK2_ORIGIN_SCHEMA,
+        "normalized_schema": OSTI_NORMALIZED_SCHEMA,
+    },
+    "legacy": {
+        "api": "legacy",
+        "origin_schema": OSTI_LEGACY_ORIGIN_SCHEMA,
+        "normalized_schema": OSTI_NORMALIZED_SCHEMA,
+    },
+}
 
 
 class DateTimeEncoder(json.JSONEncoder):
@@ -26,7 +44,12 @@ class DateTimeEncoder(json.JSONEncoder):
 class OSTIRecordRetriever:
     """Retrieve records from OSTI E-Link 2.0 API."""
 
-    def __init__(self, api_key: Optional[str] = None, api_url: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
+        legacy_api_url: str = OSTI_PUBLIC_API_RECORDS_URL,
+    ):
         """
         Initialize the OSTI record retriever.
 
@@ -36,6 +59,7 @@ class OSTIRecordRetriever:
         """
         # Use provided API key, or try to get from environment
         self.api = _init_api(api_key, api_url)
+        self.legacy_api_url = legacy_api_url
 
     def get_record_by_osti_id(self, osti_id: Union[int, str]) -> Optional[Dict[str, Any]]:
         """
@@ -161,6 +185,195 @@ class OSTIRecordRetriever:
         logger.info(f"Retrieved {len(records)} records total")
         return records
 
+    def query_elink2_records(
+        self,
+        site_code: str,
+        product_type: Optional[str] = None,
+        entry_date_start: Optional[str] = None,
+        entry_date_end: Optional[str] = None,
+        rows: int = 500,
+        limit: Optional[int] = None,
+    ) -> tuple[list[dict], dict]:
+        """Query E-Link 2.0 records for a submitting site code."""
+        params = {
+            "site_ownership_code": site_code,
+            "rows": rows,
+        }
+        if product_type:
+            params["product_type"] = product_type
+        if entry_date_start:
+            params["entry_date_start"] = _format_osti_api_date(entry_date_start)
+        if entry_date_end:
+            params["entry_date_end"] = _format_osti_api_date(entry_date_end)
+
+        query = self.api.query_records(**params)
+        records = []
+        for idx, record in enumerate(query):
+            if limit is not None and idx >= limit:
+                break
+            records.append(self.api.record_to_dict(record))
+
+        source_metadata = _source_metadata(
+            source="elink2",
+            query_params=params,
+            total_rows=query.total_rows,
+            record_count=len(records),
+        )
+        return records, source_metadata
+
+    def query_legacy_records(
+        self,
+        site_code: str,
+        product_type: Optional[str] = None,
+        entry_date_start: Optional[str] = None,
+        entry_date_end: Optional[str] = None,
+        rows: int = 500,
+        limit: Optional[int] = None,
+    ) -> tuple[list[dict], dict]:
+        """Query OSTI public API v1 records using legacy OSTI record fields."""
+        params = {
+            "site_ownership_code": site_code,
+            "rows": rows,
+            "sort": "entry_date",
+            "order": "desc",
+        }
+        if product_type:
+            params["product_type"] = product_type
+        if entry_date_start:
+            params["entry_date_start"] = _format_osti_api_date(entry_date_start)
+        if entry_date_end:
+            params["entry_date_end"] = _format_osti_api_date(entry_date_end)
+        if limit is not None:
+            params["rows"] = min(rows, limit)
+
+        records, response_metadata = self._query_legacy_api(params)
+        if limit is not None:
+            records = records[:limit]
+
+        source_metadata = _source_metadata(
+            source="legacy",
+            query_params=params,
+            total_rows=response_metadata.get("total_rows"),
+            record_count=len(records),
+        )
+        return records, source_metadata
+
+    def retrieve_records_by_site_code(
+        self,
+        site_code: str,
+        sources: tuple[str, ...] = ("legacy", "elink2"),
+        product_type: Optional[str] = None,
+        entry_date_start: Optional[str] = None,
+        entry_date_end: Optional[str] = None,
+        rows: int = 500,
+        limit: Optional[int] = None,
+    ) -> dict:
+        """Retrieve records for a site code from one or more OSTI source APIs."""
+        site_code = site_code.strip().upper()
+        records = []
+        record_origins = []
+        retrieval_sources = []
+
+        for source in sources:
+            if source == "legacy":
+                source_records, source_metadata = self.query_legacy_records(
+                    site_code=site_code,
+                    product_type=product_type,
+                    entry_date_start=entry_date_start,
+                    entry_date_end=entry_date_end,
+                    rows=rows,
+                    limit=limit,
+                )
+            elif source == "elink2":
+                source_records, source_metadata = self.query_elink2_records(
+                    site_code=site_code,
+                    product_type=product_type,
+                    entry_date_start=entry_date_start,
+                    entry_date_end=entry_date_end,
+                    rows=rows,
+                    limit=limit,
+                )
+            else:
+                raise ValueError(f"Unknown OSTI source API: {source}")
+
+            retrieval_sources.append(source_metadata)
+            origin_schema = source_metadata["origin_schema"]
+            for record in source_records:
+                record_origins.append(
+                    {
+                        "record_index": len(records),
+                        "osti_id": record.get("osti_id"),
+                        "source": source,
+                        "origin_schema": origin_schema,
+                        "normalized_schema": OSTI_NORMALIZED_SCHEMA,
+                    }
+                )
+                records.append(record)
+
+        return {
+            "source_query": {
+                "site_code": site_code,
+                "product_type": product_type,
+                "entry_date_start": entry_date_start,
+                "entry_date_end": entry_date_end,
+                "sources": list(sources),
+            },
+            "retrieval_sources": retrieval_sources,
+            "record_origins": record_origins,
+            "records": records,
+        }
+
+    def save_records_by_site_code_to_file(
+        self,
+        output_path: Union[str, Path],
+        site_code: str,
+        sources: tuple[str, ...] = ("legacy", "elink2"),
+        product_type: Optional[str] = None,
+        entry_date_start: Optional[str] = None,
+        entry_date_end: Optional[str] = None,
+        rows: int = 500,
+        limit: Optional[int] = None,
+        pretty: bool = True,
+    ) -> dict:
+        """Retrieve site-code records and save them with source-origin metadata."""
+        output_data = self.retrieve_records_by_site_code(
+            site_code=site_code,
+            sources=sources,
+            product_type=product_type,
+            entry_date_start=entry_date_start,
+            entry_date_end=entry_date_end,
+            rows=rows,
+            limit=limit,
+        )
+
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            if pretty:
+                json.dump(output_data, f, indent=2,
+                          ensure_ascii=False, cls=DateTimeEncoder)
+            else:
+                json.dump(output_data, f, ensure_ascii=False,
+                          cls=DateTimeEncoder)
+
+        logger.info(
+            f"Saved {len(output_data['records'])} site-code record(s) to {output_path}")
+        return output_data
+
+    def _query_legacy_api(self, params: dict) -> tuple[list[dict], dict]:
+        query_url = f"{self.legacy_api_url}?{urlencode(params)}"
+        request = Request(query_url, headers={"Accept": "application/json"})
+        with urlopen(request) as response:
+            payload = response.read().decode("utf-8")
+            total_rows = response.headers.get("X-Total-Count")
+        records = json.loads(payload)
+        if isinstance(records, dict):
+            records = [records]
+        return records, {
+            "total_rows": int(total_rows) if total_rows is not None else None,
+        }
+
     def save_records_to_file(
         self,
         output_path: Union[str, Path],
@@ -245,6 +458,30 @@ def retrieve_osti_records(
         )
 
     return retriever.get_records(osti_ids=osti_ids, dois=dois)
+
+
+def _format_osti_api_date(value):
+    """Format ISO dates as the MM/DD/YYYY query dates accepted by OSTI APIs."""
+    if not value:
+        return None
+    value = str(value).strip()
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        return value
+    return parsed.strftime("%m/%d/%Y")
+
+
+def _source_metadata(source, query_params, total_rows, record_count):
+    metadata = dict(OSTI_SOURCE_METADATA[source])
+    metadata.update(
+        {
+            "query_params": {key: value for key, value in query_params.items() if value is not None},
+            "total_rows": total_rows,
+            "record_count": record_count,
+        }
+    )
+    return metadata
 
 
 class MultipleMatchesError(Exception):

--- a/src/brc_schema/util/elink.py
+++ b/src/brc_schema/util/elink.py
@@ -18,14 +18,14 @@ logger = logging.getLogger(__name__)
 OSTI_DOI_PREFIX = "10.11578/"
 OSTI_PUBLIC_API_RECORDS_URL = "https://www.osti.gov/api/v1/records"
 OSTI_LEGACY_ELINK_API_URL = "https://www.osti.gov/elink/2416api"
-OSTI_ELINK2_ORIGIN_SCHEMA = "osti_elink2_json"
+OSTI_ELINK_ORIGIN_SCHEMA = "osti_elink2_json"
 OSTI_LEGACY_ORIGIN_SCHEMA = "osti_elink1_xml"
 OSTI_PUBLIC_ORIGIN_SCHEMA = "osti_public_api_v1_json"
 OSTI_NORMALIZED_SCHEMA = "osti_schema"
 OSTI_SOURCE_METADATA = {
     "elink2": {
         "api": "elink2",
-        "origin_schema": OSTI_ELINK2_ORIGIN_SCHEMA,
+        "origin_schema": OSTI_ELINK_ORIGIN_SCHEMA,
         "normalized_schema": OSTI_NORMALIZED_SCHEMA,
     },
     "legacy": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,3 +63,88 @@ def test_transmit_osti_limit_zero_is_respected(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert captured["record_limit"] == 0
     assert len(captured["records"]) == 1
+
+
+def test_retrieve_osti_site_defaults_to_both_sources(tmp_path, monkeypatch):
+    """retrieve-osti-site should query legacy and E-Link 2.0 by default."""
+    output_file = tmp_path / "site_records.json"
+    captured = {}
+
+    class FakeRetriever:
+        def __init__(self, api_key=None, api_url=None, legacy_api_url=None):
+            captured["api_key"] = api_key
+            captured["api_url"] = api_url
+            captured["legacy_api_url"] = legacy_api_url
+
+        def save_records_by_site_code_to_file(self, **kwargs):
+            captured.update(kwargs)
+            output_data = {
+                "retrieval_sources": [
+                    {"api": "legacy", "record_count": 1},
+                    {"api": "elink2", "record_count": 1},
+                ],
+                "records": [{"osti_id": "1"}, {"osti_id": 2}],
+            }
+            kwargs["output_path"].write_text(json.dumps(output_data), encoding="utf-8")
+            return output_data
+
+    monkeypatch.setattr("brc_schema.cli.OSTIRecordRetriever", FakeRetriever)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "retrieve-osti-site",
+            "--site-code",
+            "glbrc",
+            "--entry-date-start",
+            "2026-01-01",
+            "--limit",
+            "3",
+            "-o",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["site_code"] == "glbrc"
+    assert captured["sources"] == ("legacy", "elink2")
+    assert captured["entry_date_start"] == "2026-01-01"
+    assert captured["limit"] == 3
+    assert captured["pretty"] is True
+    assert "legacy=1, elink2=1" in result.output
+
+
+def test_retrieve_osti_site_allows_source_selection(tmp_path, monkeypatch):
+    """A caller can request only one origin API when needed."""
+    captured = {}
+
+    class FakeRetriever:
+        def __init__(self, **kwargs):
+            pass
+
+        def save_records_by_site_code_to_file(self, **kwargs):
+            captured.update(kwargs)
+            return {
+                "retrieval_sources": [{"api": "legacy", "record_count": 0}],
+                "records": [],
+            }
+
+    monkeypatch.setattr("brc_schema.cli.OSTIRecordRetriever", FakeRetriever)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "retrieve-osti-site",
+            "--site-code",
+            "CBI",
+            "--source",
+            "legacy",
+            "-o",
+            str(tmp_path / "records.json"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["sources"] == ("legacy",)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,30 +65,30 @@ def test_transmit_osti_limit_zero_is_respected(tmp_path, monkeypatch):
     assert len(captured["records"]) == 1
 
 
-def test_retrieve_osti_site_defaults_to_both_sources(tmp_path, monkeypatch):
-    """retrieve-osti-site should query legacy and E-Link 2.0 by default."""
+def test_retrieve_osti_site_defaults_to_public_without_auth(tmp_path, monkeypatch):
+    """Unauthenticated site retrieval should avoid E-Link 2 and legacy private APIs."""
     output_file = tmp_path / "site_records.json"
     captured = {}
 
     class FakeRetriever:
-        def __init__(self, api_key=None, api_url=None, legacy_api_url=None):
-            captured["api_key"] = api_key
-            captured["api_url"] = api_url
-            captured["legacy_api_url"] = legacy_api_url
+        def __init__(self, **kwargs):
+            captured["init_kwargs"] = kwargs
 
         def save_records_by_site_code_to_file(self, **kwargs):
             captured.update(kwargs)
             output_data = {
                 "retrieval_sources": [
-                    {"api": "legacy", "record_count": 1},
-                    {"api": "elink2", "record_count": 1},
+                    {"api": "public", "record_count": 1},
                 ],
-                "records": [{"osti_id": "1"}, {"osti_id": 2}],
+                "records": [{"osti_id": "1"}],
             }
             kwargs["output_path"].write_text(json.dumps(output_data), encoding="utf-8")
             return output_data
 
     monkeypatch.setattr("brc_schema.cli.OSTIRecordRetriever", FakeRetriever)
+    monkeypatch.delenv("OSTI_API_KEY", raising=False)
+    monkeypatch.delenv("OSTI_LEGACY_USERNAME", raising=False)
+    monkeypatch.delenv("OSTI_LEGACY_PASSWORD", raising=False)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -108,11 +108,53 @@ def test_retrieve_osti_site_defaults_to_both_sources(tmp_path, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["site_code"] == "glbrc"
-    assert captured["sources"] == ("legacy", "elink2")
+    assert captured["sources"] == ("public",)
     assert captured["entry_date_start"] == "2026-01-01"
     assert captured["limit"] == 3
     assert captured["pretty"] is True
-    assert "legacy=1, elink2=1" in result.output
+    assert captured["init_kwargs"]["initialize_elink2"] is False
+    assert "public=1" in result.output
+    assert "No OSTI authentication provided" in result.output
+
+
+def test_retrieve_osti_site_defaults_to_private_sources_with_auth(tmp_path, monkeypatch):
+    """When both credential types are available, default to legacy E-Link 1 plus E-Link 2."""
+    captured = {}
+
+    class FakeRetriever:
+        def __init__(self, **kwargs):
+            captured["init_kwargs"] = kwargs
+
+        def save_records_by_site_code_to_file(self, **kwargs):
+            captured.update(kwargs)
+            return {
+                "retrieval_sources": [
+                    {"api": "legacy", "record_count": 1},
+                    {"api": "elink2", "record_count": 1},
+                ],
+                "records": [{"osti_id": "1"}, {"osti_id": 2}],
+            }
+
+    monkeypatch.setattr("brc_schema.cli.OSTIRecordRetriever", FakeRetriever)
+    monkeypatch.setenv("OSTI_API_KEY", "api-token")
+    monkeypatch.setenv("OSTI_LEGACY_USERNAME", "legacy-user")
+    monkeypatch.setenv("OSTI_LEGACY_PASSWORD", "legacy-password")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "retrieve-osti-site",
+            "--site-code",
+            "glbrc",
+            "-o",
+            str(tmp_path / "records.json"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["sources"] == ("legacy", "elink2")
+    assert captured["init_kwargs"]["initialize_elink2"] is True
 
 
 def test_retrieve_osti_site_allows_source_selection(tmp_path, monkeypatch):
@@ -141,6 +183,10 @@ def test_retrieve_osti_site_allows_source_selection(tmp_path, monkeypatch):
             "CBI",
             "--source",
             "legacy",
+            "--legacy-username",
+            "user",
+            "--legacy-password",
+            "pass",
             "-o",
             str(tmp_path / "records.json"),
         ],
@@ -148,3 +194,85 @@ def test_retrieve_osti_site_allows_source_selection(tmp_path, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["sources"] == ("legacy",)
+
+
+def test_retrieve_osti_site_requires_elink2_auth_for_explicit_source(tmp_path, monkeypatch):
+    """Explicit E-Link 2 retrieval should fail before making an unauthenticated API call."""
+    monkeypatch.delenv("OSTI_API_KEY", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "retrieve-osti-site",
+            "--site-code",
+            "CBI",
+            "--source",
+            "elink2",
+            "-o",
+            str(tmp_path / "records.json"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "E-Link 2.0 retrieval requires" in result.output
+
+
+def test_retrieve_osti_site_requires_legacy_auth_for_explicit_source(tmp_path, monkeypatch):
+    """Explicit legacy E-Link 1 retrieval should fail without basic auth."""
+    monkeypatch.delenv("OSTI_LEGACY_USERNAME", raising=False)
+    monkeypatch.delenv("OSTI_LEGACY_PASSWORD", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "retrieve-osti-site",
+            "--site-code",
+            "CBI",
+            "--source",
+            "legacy",
+            "-o",
+            str(tmp_path / "records.json"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Legacy E-Link 1 retrieval requires" in result.output
+
+
+def test_retrieve_osti_site_warns_for_explicit_public_without_auth(tmp_path, monkeypatch):
+    """Explicit public-only retrieval should still disclose unauthenticated limits."""
+    output_file = tmp_path / "site_records.json"
+
+    class FakeRetriever:
+        def __init__(self, **kwargs):
+            pass
+
+        def save_records_by_site_code_to_file(self, **kwargs):
+            return {
+                "retrieval_sources": [{"api": "public", "record_count": 1}],
+                "records": [{"osti_id": "1"}],
+            }
+
+    monkeypatch.setattr("brc_schema.cli.OSTIRecordRetriever", FakeRetriever)
+    monkeypatch.delenv("OSTI_API_KEY", raising=False)
+    monkeypatch.delenv("OSTI_LEGACY_USERNAME", raising=False)
+    monkeypatch.delenv("OSTI_LEGACY_PASSWORD", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "retrieve-osti-site",
+            "--site-code",
+            "CBI",
+            "--source",
+            "public",
+            "-o",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "No OSTI authentication provided" in result.output

--- a/tests/test_elink.py
+++ b/tests/test_elink.py
@@ -14,6 +14,7 @@ from brc_schema.util.elink import (
     TransmitSummary,
     MultipleMatchesError,
     _format_osti_api_date,
+    _parse_legacy_elink_xml,
 )
 
 
@@ -47,9 +48,9 @@ class TestOSTIRecordRetriever:
                 [{"osti_id": "111", "title": "Legacy record"}],
                 {
                     "api": "legacy",
-                    "origin_schema": "osti_public_api_v1_json",
+                    "origin_schema": "osti_elink1_xml",
                     "normalized_schema": "osti_schema",
-                    "query_params": {"site_ownership_code": "GLBRC"},
+                    "query_params": {"site_input_code": "GLBRC"},
                     "total_rows": 1,
                     "record_count": 1,
                 },
@@ -86,7 +87,7 @@ class TestOSTIRecordRetriever:
                 "record_index": 0,
                 "osti_id": "111",
                 "source": "legacy",
-                "origin_schema": "osti_public_api_v1_json",
+                "origin_schema": "osti_elink1_xml",
                 "normalized_schema": "osti_schema",
             },
             {
@@ -99,7 +100,7 @@ class TestOSTIRecordRetriever:
         ]
 
     def test_query_legacy_records_uses_site_code_and_entry_dates(self, monkeypatch):
-        """Legacy API queries should use OSTI public API date/query conventions."""
+        """Legacy API queries should use E-Link 1 query conventions."""
         retriever = OSTIRecordRetriever(api_key="test_key")
         captured = {}
 
@@ -122,14 +123,63 @@ class TestOSTIRecordRetriever:
         )
 
         assert records == [{"osti_id": "333", "title": "Legacy queried record"}]
-        assert captured["site_ownership_code"] == "CBI"
+        assert captured["site_input_code"] == "CBI"
         assert captured["entry_date_start"] == "01/02/2026"
         assert captured["entry_date_end"] == "02/03/2026"
         assert captured["rows"] == 10
         assert metadata["api"] == "legacy"
-        assert metadata["origin_schema"] == "osti_public_api_v1_json"
+        assert metadata["origin_schema"] == "osti_elink1_xml"
         assert metadata["total_rows"] == 7
         assert metadata["record_count"] == 1
+
+    def test_query_public_records_tracks_public_origin_schema(self, monkeypatch):
+        """Public fallback should be labeled separately from legacy E-Link 1."""
+        retriever = OSTIRecordRetriever(api_key="test_key")
+        captured = {}
+
+        def fake_query(params):
+            captured.update(params)
+            return (
+                [{"osti_id": "333", "title": "Public record"}],
+                {"total_rows": 7},
+            )
+
+        monkeypatch.setattr(retriever, "_query_public_api", fake_query)
+
+        records, metadata = retriever.query_public_records(
+            site_code="CBI",
+            entry_date_start="2026-01-02",
+            rows=500,
+            limit=10,
+        )
+
+        assert records == [{"osti_id": "333", "title": "Public record"}]
+        assert captured["site_ownership_code"] == "CBI"
+        assert captured["entry_date_start"] == "01/02/2026"
+        assert metadata["api"] == "public"
+        assert metadata["origin_schema"] == "osti_public_api_v1_json"
+
+    def test_parse_legacy_elink_xml_normalizes_common_fields(self):
+        """Legacy XML responses should become transform-friendly record dictionaries."""
+        records = _parse_legacy_elink_xml(
+            """
+            <records>
+              <record>
+                <osti_id>123</osti_id>
+                <site_input_code>CBI</site_input_code>
+                <contract_nos>AC36-08GO28308</contract_nos>
+                <originating_research_org>Oak Ridge National Laboratory</originating_research_org>
+              </record>
+            </records>
+            """
+        )
+
+        assert records == [{
+            "osti_id": "123",
+            "site_ownership_code": "CBI",
+            "doe_contract_number": "AC36-08GO28308",
+            "research_orgs": "Oak Ridge National Laboratory",
+        }]
 
     def test_format_osti_api_date_accepts_iso_and_passthrough(self):
         """CLI-friendly ISO dates should become OSTI API query dates."""

--- a/tests/test_elink.py
+++ b/tests/test_elink.py
@@ -12,7 +12,8 @@ from brc_schema.util.elink import (
     OSTIRecordTransmitter,
     retrieve_osti_records,
     TransmitSummary,
-    MultipleMatchesError
+    MultipleMatchesError,
+    _format_osti_api_date,
 )
 
 
@@ -36,6 +37,104 @@ class TestOSTIRecordRetriever:
         """Test initialization with API key."""
         retriever = OSTIRecordRetriever(api_key="test_key")
         assert retriever.api is not None
+
+    def test_retrieve_records_by_site_code_tracks_origin_schemas(self, monkeypatch):
+        """Combined site-code retrieval should keep records transform-compatible and traceable."""
+        retriever = OSTIRecordRetriever(api_key="test_key")
+
+        def fake_legacy_records(**kwargs):
+            return (
+                [{"osti_id": "111", "title": "Legacy record"}],
+                {
+                    "api": "legacy",
+                    "origin_schema": "osti_public_api_v1_json",
+                    "normalized_schema": "osti_schema",
+                    "query_params": {"site_ownership_code": "GLBRC"},
+                    "total_rows": 1,
+                    "record_count": 1,
+                },
+            )
+
+        def fake_elink2_records(**kwargs):
+            return (
+                [{"osti_id": 222, "title": "E-Link 2 record"}],
+                {
+                    "api": "elink2",
+                    "origin_schema": "osti_elink2_json",
+                    "normalized_schema": "osti_schema",
+                    "query_params": {"site_ownership_code": "GLBRC"},
+                    "total_rows": 1,
+                    "record_count": 1,
+                },
+            )
+
+        monkeypatch.setattr(retriever, "query_legacy_records", fake_legacy_records)
+        monkeypatch.setattr(retriever, "query_elink2_records", fake_elink2_records)
+
+        result = retriever.retrieve_records_by_site_code(
+            site_code="glbrc",
+            sources=("legacy", "elink2"),
+        )
+
+        assert result["source_query"]["site_code"] == "GLBRC"
+        assert result["records"] == [
+            {"osti_id": "111", "title": "Legacy record"},
+            {"osti_id": 222, "title": "E-Link 2 record"},
+        ]
+        assert result["record_origins"] == [
+            {
+                "record_index": 0,
+                "osti_id": "111",
+                "source": "legacy",
+                "origin_schema": "osti_public_api_v1_json",
+                "normalized_schema": "osti_schema",
+            },
+            {
+                "record_index": 1,
+                "osti_id": 222,
+                "source": "elink2",
+                "origin_schema": "osti_elink2_json",
+                "normalized_schema": "osti_schema",
+            },
+        ]
+
+    def test_query_legacy_records_uses_site_code_and_entry_dates(self, monkeypatch):
+        """Legacy API queries should use OSTI public API date/query conventions."""
+        retriever = OSTIRecordRetriever(api_key="test_key")
+        captured = {}
+
+        def fake_query(params):
+            captured.update(params)
+            return (
+                [{"osti_id": "333", "title": "Legacy queried record"}],
+                {"total_rows": 7},
+            )
+
+        monkeypatch.setattr(retriever, "_query_legacy_api", fake_query)
+
+        records, metadata = retriever.query_legacy_records(
+            site_code="CBI",
+            product_type="Journal Article",
+            entry_date_start="2026-01-02",
+            entry_date_end="2026-02-03",
+            rows=500,
+            limit=10,
+        )
+
+        assert records == [{"osti_id": "333", "title": "Legacy queried record"}]
+        assert captured["site_ownership_code"] == "CBI"
+        assert captured["entry_date_start"] == "01/02/2026"
+        assert captured["entry_date_end"] == "02/03/2026"
+        assert captured["rows"] == 10
+        assert metadata["api"] == "legacy"
+        assert metadata["origin_schema"] == "osti_public_api_v1_json"
+        assert metadata["total_rows"] == 7
+        assert metadata["record_count"] == 1
+
+    def test_format_osti_api_date_accepts_iso_and_passthrough(self):
+        """CLI-friendly ISO dates should become OSTI API query dates."""
+        assert _format_osti_api_date("2026-01-02") == "01/02/2026"
+        assert _format_osti_api_date("01/02/2026") == "01/02/2026"
 
     @pytest.mark.integration
     @skip_if_no_api_key


### PR DESCRIPTION
## Summary
- add `retrieve-osti-site` to retrieve site-code records from legacy/public OSTI API records, E-Link 2.0 records, or both
- include `retrieval_sources` and per-record `record_origins` metadata so each record has an explicit origin schema while keeping `records` transform-compatible
- document the new CLI workflow and add tests for source selection, date formatting, and origin metadata

Fixes #95

## Testing
- uv run pytest -q tests/test_cli.py tests/test_elink.py
- uv run brcschema retrieve-osti-site --site-code GLBRC --limit 1 --api-key "$(tr -d "\r\n" < osti_tok)" -o /tmp/glbrc_site_records.json
- make test
- uv run mkdocs build --strict
- git diff --check